### PR TITLE
Path to fix Build make failing with - multiple definition of toplevel

### DIFF
--- a/common/tftpsubs.h
+++ b/common/tftpsubs.h
@@ -118,4 +118,9 @@ extern int segsize;
 int pick_port_bind(int sockfd, union sock_addr *myaddr,
                    unsigned int from, unsigned int to);
 
+#ifndef _TOP_LEVEL_
+#define _TOP_LEVEL_
+static sigjmp_buf toplevel;
+#endif
+
 #endif

--- a/tftp/main.c
+++ b/tftp/main.c
@@ -95,7 +95,6 @@ char line[LBUFLEN];
 int margc;
 char *margv[20];
 const char *prompt = "tftp> ";
-sigjmp_buf toplevel;
 void intr(int);
 struct servent *sp;
 int portrange = 0;

--- a/tftp/tftp.c
+++ b/tftp/tftp.c
@@ -48,7 +48,6 @@ extern int maxtimeout;
 #define PKTSIZE    SEGSIZE+4
 char ackbuf[PKTSIZE];
 int timeout;
-sigjmp_buf toplevel;
 sigjmp_buf timeoutbuf;
 
 static void nak(int, const char *);


### PR DESCRIPTION
Patch based on comments found in https://stackoverflow.com/questions/68982596/multiple-definition-error-while-compiling-tftp-hpa